### PR TITLE
add polarwatch access page

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -42,6 +42,7 @@ parts:
       - file: content/data_access/access_opendap/opendap_interface.md
       - file: content/data_access/access_opendap/python_get_cefi.ipynb
       - file: content/data_access/access_opendap/r_get_cefi.ipynb
+    - file: content/data_access/access_polar.md
     - file: content/data_access/data_faq.md
 
   - caption: Other Resources

--- a/content/data_access/access_polar.md
+++ b/content/data_access/access_polar.md
@@ -1,0 +1,20 @@
+NOAA PolarWatch
+===
+## What is NOAA PolarWatch
+[NOAA PolarWatch](https://polarwatch.noaa.gov) is a data and code repository designed to provide the public with open access to a wide range of Arctic and Antarctic observational data. It offers two main functionalities:
+
+- Data Access: Access to various datasets, including sea ice surface temperature, sea surface height, and sea ice thickness, among others.
+- Tutorials: Step-by-step guides demonstrating quick access and data preprocessing techniques for many datasets in polar stereographic projection.
+
+## How is it related to CEFI
+The NOAA PolarWatch observational data serve as a valuable repository for validating the regional MOM6 simulations provided by CEFI. The Arctic region under development will specifically align with the regional coverage of PolarWatch data. Additionally, the northern areas of the Northeast Pacific and Northwest Atlantic will include some polar regions.
+
+The polar stereographic projection techniques outlined in the tutorial will be particularly relevant and useful for visualizing model outputs for the Arctic region.
+
+## Data Access
+The data can be downloaded or accessed in two ways provided by PolarWatch:
+1. [Data portal](https://polarwatch.noaa.gov/catalog/list.php): This offers a quick overview of the data along with a full catalog of the hosted datasets.
+2. [ERDDAP server](https://polarwatch.noaa.gov/erddap/info/index.html?page=1&itemsPerPage=1000): This provides access to all the data hosted on PolarWatch.
+
+## Tutorials
+The tutorials provided by PolarWatch consist of various example use cases. The [code gallery](https://polarwatch.noaa.gov/tools-training/code-gallery/) offers an attractive tile overview of the available tutorials. Each tutorial links to a [GitHub repository](https://github.com/coastwatch-training/CoastWatch-Tutorials) hosting Python or R notebooks that demonstrate how to access and preprocess the data, complete with detailed markdown explanations.


### PR DESCRIPTION
The PR put the polar watch access under the data access chapter. A draft intro is created and if more example is need to be extended. A dir that under this title can be created. Currently, we will only include the intro page.